### PR TITLE
Fix the mis-translation of the code part.

### DIFF
--- a/docs/readme Japanese Version.md
+++ b/docs/readme Japanese Version.md
@@ -160,7 +160,7 @@ layout = [[sg.Text("お名前は何ですか？")],
           [sg.Button('はい'), sg.Button('終了')]]
 
 # ウィンドウを作成する
-window = sg.Window('ウィンドウタイトル',レイアウト)
+window = sg.Window('ウィンドウタイトル',layout)
 
 # イベントループを使用してウィンドウを表示し、対話する
 while True:


### PR DESCRIPTION
変数名(`layout`)がコードの途中で`レイアウト`に変わっており、`レイアウト`を`layout`に直さなければコードが動かなくなっていたため、修正しました。